### PR TITLE
Adding the graalVMBuildContainerOptions key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ target/
 .cache
 .ensime*
 .bloop/*
+.bsp/
 .metals/*

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
@@ -8,6 +8,9 @@ import sbt._
   * GraalVM settings
   */
 trait GraalVMNativeImageKeys {
+  val graalVMBuildContainerOptions =
+    settingKey[Seq[String]]("GraalVM build container options, ex: --user")
+
   val graalVMNativeImageOptions =
     settingKey[Seq[String]]("GraalVM native-image options")
 


### PR DESCRIPTION
## GraalVM Build In Container

Feature to allow passing docker container start up options to the docker image that builds the graal image.

On Linux the exported graalVM binary was exported as the root user preventing deletion of the target folders via the ide as the ide/user doesn't have permissions due to the graalVM directory being owned by root. 

This required sudo rm -rf to be called on the folder to get permissions. 

Adding the graalVMBuildContainerOptions key and adding the related value to the buildInDockerContainer method.

This allows the setting of options for the docker container that will build the graalVM binary, for example 
`Seq("--user", "1000:1000")`

Additionally, by implementing it as an options settings key allows for setting other docker environment values.